### PR TITLE
Player transport to Level 2

### DIFF
--- a/Lights Out/Maps/Map2/Corridor_Map2.tscn
+++ b/Lights Out/Maps/Map2/Corridor_Map2.tscn
@@ -62,7 +62,4 @@ width = 1.05336
 height = 0.402552
 depth = 0.0627017
 
-[node name="Camera" type="Camera" parent="."]
-transform = Transform( -4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, -18.6571, -24.4587, -34.2408 )
-
 [connection signal="body_entered" from="Door/Area" to="Door" method="_on_Area_body_entered"]

--- a/Lights Out/Maps/Map2/Map2.tscn
+++ b/Lights Out/Maps/Map2/Map2.tscn
@@ -1,8 +1,13 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
-[sub_resource type="Environment" id=1]
+[ext_resource path="res://Maps/Map2/Corridor_Map2.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Maps/LoadPlayer.gd" type="Script" id=2]
 
 [node name="Spatial" type="Spatial"]
+script = ExtResource( 2 )
 
-[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
-environment = SubResource( 1 )
+[node name="Spawn" type="Spatial" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0763985, 2.58362, -7.10119 )
+
+[node name="Corridor_Map2" parent="." instance=ExtResource( 1 )]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 18.0432, 26.7744, 32.9909 )


### PR DESCRIPTION
the end door is finalised in base components as the player can walk into the door after unlocking its lock. The player is, however, short. This may be due to the scaling of map2's environment.